### PR TITLE
Improve method naming

### DIFF
--- a/lib/tzu/validation.rb
+++ b/lib/tzu/validation.rb
@@ -20,7 +20,7 @@ module Tzu
     end
 
     def invalid!(obj)
-      methods = (rails_6_1_active_model?(obj) ? [] : [:errors]) + [:messages, :message]
+      methods = (rails_6_1_active_model_errors?(obj) ? [] : [:errors]) + [:messages, :message]
       output = methods.reduce(obj) do |result, m|
         result.respond_to?(m) ? result.send(m) : result
       end
@@ -39,7 +39,7 @@ module Tzu
     # https://github.com/rails/rails/pull/32313. To ensure the same
     # outcome as with previous rails versions, we forbid any calls to
     # `ActiveModel::Errors#errors`.
-    def rails_6_1_active_model?(obj)
+    def rails_6_1_active_model_errors?(obj)
       return false unless defined?(ActiveModel)
 
       obj.is_a?(ActiveModel::Errors) && obj.respond_to?(:errors)


### PR DESCRIPTION
The private method `Tzu::Validation#rails_6_1_active_model?` is not precise enough. We want to validate that the given object is a `ActiveModel::Errors` provided by Rails >= 6.1. So we rename it `rails_6_1_active_model_errors?`.